### PR TITLE
Refactor partial reorthogonalization code

### DIFF
--- a/src/svd.jl
+++ b/src/svd.jl
@@ -182,7 +182,7 @@ function _tsvd(A,
 
     hasConv = false
     while iter <= maxIter
-        _, _, _, _, ω =
+        _1, _2, _3, _4, ω =
             biLanczosIterations(A, stepSize, αs, βs, U, V, ω, debug)
         iter += stepSize
 

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -164,14 +164,8 @@ function _tsvd(A,
     ω = OmegaRecurrence{Tr}(tolReorth, false, false,
         τ, [μ, 1], [one(μ)], Tr[], Tr[], 0, 0) #???? [one(μ)] NOT [ν]?
 
-    # return types can only be inferred by man, not the machine
-    αs::Vector{Tr},
-    βs::Vector{Tr},
-    U::Vector{typeof(v)}, # for some reason typeof(U) doesn't work here
-    V::Vector{typeof(v)},
-    ω::OmegaRecurrence{Tr} = biLanczosIterations(A, nVals - 1, [α], [β],
-            typeof(u)[uOld, u], typeof(v)[v],
-            ω, debug)
+    αs,βs,U,V,ω = biLanczosIterations(
+        A, nVals - 1, [α], [β], typeof(u)[uOld, u], typeof(v)[v], ω, debug)
 
     # Iteration count
     iter = nVals
@@ -207,9 +201,7 @@ function _tsvd(A,
         debug && @show iter
         debug && @show ω.τ
     end
-    if !hasConv
-        error("no convergence")
-    end
+    hasConv || error("no convergence")
 
     # Form upper bidiagonal square matrix
     # m = length(U[1])

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -234,7 +234,7 @@ function _tsvd(A,
     return (mU*smU)[:,1:nVals],
         sms[1:nVals],
         (mV*smV)[:,1:nVals],
-        Bidiagonal(αs, βs[1:end-1], false),
+        Bidiagonal(αs, βs[1:end-1], false), β,
         mU,
         mV,
         ω

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -93,8 +93,7 @@ function biLanczosIterations(A, stepSize, αs, βs, U, V, μs, νs, τ, reorth_i
 
         # The v step
         vOld = v
-        ## apply operator
-        v = A'u
+        v = A'u ## apply operator
         axpy!(T(-β), vOld, v)
         α = norm(v)
 
@@ -112,8 +111,7 @@ function biLanczosIterations(A, stepSize, αs, βs, U, V, μs, νs, τ, reorth_i
 
         # The u step
         uOld = u
-        ## apply operator
-        u = A*v
+        u = A*v ## apply operator
         axpy!(T(-α), uOld, u)
         β = norm(u)
 
@@ -272,8 +270,6 @@ end
 Computes the truncated singular value decomposition (TSVD) by Lanczos bidiagonalization of the operator `A`. The Lanczos vectors are partially orthogonalized as described in
 
 R. M. Larsen, *Lanczos bidiagonalization with partial reorthogonalization*, Department of Computer Science, Aarhus University, Technical report, DAIMI PB-357, September 1998.
-
-Note! At the moment the default is complete orthogonalization because the ω recurrences that measure the orthogonality of the Lanczos vectors still requires some fine tuning.
 
 **Arguments:**
 


### PR DESCRIPTION
Data for the omega recurrence are now in a separate `OmegaRecurrence` type.

Needs to be checked to make sure the recurrences are actually correct.
