### PR TITLE
minor Julia 0.7/1.0 edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:

--- a/src/TSVD.jl
+++ b/src/TSVD.jl
@@ -1,7 +1,4 @@
 # Copyright 2015-2018 Andreas Noack
-
-# __precompile__() # not sure from which Julia version on this is obsolete
-
 module TSVD
 
     export tsvd

--- a/src/TSVD.jl
+++ b/src/TSVD.jl
@@ -1,13 +1,13 @@
 # Copyright 2015-2018 Andreas Noack
 
-__precompile__()
+# __precompile__() # not sure from which Julia version on this is obsolete
 
 module TSVD
 
     export tsvd
 
     import Base: *, hcat, maximum, size
-    import LinearAlgebra: A_mul_B!, Ac_mul_B!, axpy!, mul!
+    import LinearAlgebra: axpy!, mul!
 
     using LinearAlgebra
     using LinearAlgebra: BlasComplex, BlasFloat, BlasInt, BlasReal


### PR DESCRIPTION
* travis test against Julia 1.0
* remove A*_mul_B! imports
* remove __precompile__()

I just stumbled upon the `A_mul_B!` and `A_mul_Bc!` import warnings. Feel free to modify (e.g., add a Project.toml file?, REQUIRE?).