### PR TITLE
Factor the complete bidiagonalization into separate function such

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.7
+Adapt

--- a/src/TSVD.jl
+++ b/src/TSVD.jl
@@ -8,6 +8,7 @@ module TSVD
 
     using LinearAlgebra
     using LinearAlgebra: BlasComplex, BlasFloat, BlasInt, BlasReal
+    using Adapt: adapt
 
     include("common.jl")
     include("eig.jl")


### PR DESCRIPTION
that the call to the bidiagonal SVD solver only happens in the _tsvd
function.

Introduce dependency on Adapt to make tsvd work for CuArrays. Since
we solve the bidiagonal problem on the CPU devide we need a way to
convert the result of the bidiagonal SVD to the original deivce of
the computation. This should also work in the distributed case.

Clean up the code to avoid returning many object from the Lanczos
iteration function.